### PR TITLE
added support for partial search with test

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -62,7 +62,7 @@
   };
 
   var getType = function(field, schema) {
-    return types[schema[field] || 'string'];
+    return types[schema[field]] ? types[schema[field]]: {};
   };
 
   var getOperator = function(code) {
@@ -117,7 +117,7 @@
         if (isDefined(value)) {
           values.push(value);
         }
-      })
+      });
       return createDisjunction(values);
     }
     if (isDefined(value.$from) && isDefined(value.$to)) {
@@ -142,6 +142,9 @@
         var type = getType(field, schema);
         var value = formatValue(type, obj[field]);
         if (isDefined(value)) {
+          if (!type.suffix) {
+            type.suffix = '';
+          }
           result.push(escapeKey(field) + type.suffix + ':' + value);
         }
       }

--- a/generator.js
+++ b/generator.js
@@ -62,7 +62,7 @@
   };
 
   var getType = function(field, schema) {
-    return types[schema[field]] ? types[schema[field]]: {};
+    return types[schema[field] || 'string'];
   };
 
   var getOperator = function(code) {
@@ -117,7 +117,7 @@
         if (isDefined(value)) {
           values.push(value);
         }
-      });
+      })
       return createDisjunction(values);
     }
     if (isDefined(value.$from) && isDefined(value.$to)) {
@@ -139,12 +139,16 @@
     var result = [];
     Object.keys(obj).forEach(function(field) {
       if (isDefined(obj[field])) {
-        var type = getType(field, schema);
+        var type;
+        if (schema === 'noFormat') {
+          type = {
+            suffix: ''
+          };
+        } else {
+          type = getType(field, schema);
+        }
         var value = formatValue(type, obj[field]);
         if (isDefined(value)) {
-          if (!type.suffix) {
-            type.suffix = '';
-          }
           result.push(escapeKey(field) + type.suffix + ':' + value);
         }
       }

--- a/tests/convert.js
+++ b/tests/convert.js
@@ -40,7 +40,7 @@ exports['evaluates nested query: x AND (y OR z)'] = function(test) {
     $operator: 'and',
     $operands: [
       { name: 'gareth' },
-      { 
+      {
         $operator: 'or',
         $operands: [
           { job: 'geek' },
@@ -58,7 +58,7 @@ exports['evaluates nested query: x OR (y AND z)'] = function(test) {
     $operator: 'or',
     $operands: [
       { job: 'geek' },
-      { 
+      {
         $operator: 'and',
         $operands: [
           { job: 'musician' },
@@ -76,7 +76,7 @@ exports['evaluates multiple nested query: w OR (x AND (y OR z))'] = function(tes
     $operator: 'or',
     $operands: [
       { name: 'gareth' },
-      { 
+      {
         $operator: 'and',
         $operands: [
           { language: 'javascript' },
@@ -344,7 +344,7 @@ exports['wraps named fields'] = function(test) {
   var actual = generator.convert({
     $operands: { id: 'abc-123+xyz' }
   });
-  test.equals('id:"abc-123+xyz"', actual);
+  test.equals('id:abc-123+xyz', actual);
   test.done();
 };
 
@@ -352,6 +352,6 @@ exports['escapes quotes in named fields'] = function(test) {
   var actual = generator.convert({
     $operands: { id: 'abc-123+"xyz"' }
   });
-  test.equals('id:"abc-123+\\"xyz\\""', actual);
+  test.equals('id:abc-123+"xyz"', actual);
   test.done();
 };

--- a/tests/convert.js
+++ b/tests/convert.js
@@ -344,7 +344,7 @@ exports['wraps named fields'] = function(test) {
   var actual = generator.convert({
     $operands: { id: 'abc-123+xyz' }
   });
-  test.equals('id:abc-123+xyz', actual);
+  test.equals('id:"abc-123+xyz"', actual);
   test.done();
 };
 
@@ -352,6 +352,6 @@ exports['escapes quotes in named fields'] = function(test) {
   var actual = generator.convert({
     $operands: { id: 'abc-123+"xyz"' }
   });
-  test.equals('id:abc-123+"xyz"', actual);
+  test.equals('id:"abc-123+\\"xyz\\""', actual);
   test.done();
 };

--- a/tests/convert.js
+++ b/tests/convert.js
@@ -355,3 +355,11 @@ exports['escapes quotes in named fields'] = function(test) {
   test.equals('id:"abc-123+\\"xyz\\""', actual);
   test.done();
 };
+
+exports['no formatting for partial search'] = function(test) {
+  var actual = generator.convert({
+    $operands: { id: 'che*' }
+  });
+  test.equals('id:che*', actual);
+  test.done();
+};

--- a/tests/convert.js
+++ b/tests/convert.js
@@ -40,7 +40,7 @@ exports['evaluates nested query: x AND (y OR z)'] = function(test) {
     $operator: 'and',
     $operands: [
       { name: 'gareth' },
-      {
+      { 
         $operator: 'or',
         $operands: [
           { job: 'geek' },
@@ -58,7 +58,7 @@ exports['evaluates nested query: x OR (y AND z)'] = function(test) {
     $operator: 'or',
     $operands: [
       { job: 'geek' },
-      {
+      { 
         $operator: 'and',
         $operands: [
           { job: 'musician' },
@@ -76,7 +76,7 @@ exports['evaluates multiple nested query: w OR (x AND (y OR z))'] = function(tes
     $operator: 'or',
     $operands: [
       { name: 'gareth' },
-      {
+      { 
         $operator: 'and',
         $operands: [
           { language: 'javascript' },

--- a/tests/convert.js
+++ b/tests/convert.js
@@ -359,7 +359,7 @@ exports['escapes quotes in named fields'] = function(test) {
 exports['no formatting for partial search'] = function(test) {
   var actual = generator.convert({
     $operands: { id: 'che*' }
-  });
+  }, {schema: 'noFormat'});
   test.equals('id:che*', actual);
   test.done();
 };


### PR DESCRIPTION
This allows partial search functionality. Like if we search for `'name: che*`', we should get all the results containing cheese, chess etc. Added `noFormat`flag for by passing the string conversion as for the partial search to work, the key value pair should go as it is without any double quotes around the value.
